### PR TITLE
Consider emoji when removing kerning from last character

### DIFF
--- a/Sources/Composable.swift
+++ b/Sources/Composable.swift
@@ -275,7 +275,8 @@ extension NSMutableAttributedString {
             return
         }
 
-        let lastCharacterRange = NSRange(location: length - 1, length: 1)
+        let lastCharacterLength = string.suffix(1).utf16.count
+        let lastCharacterRange = NSRange(location: length - lastCharacterLength, length: lastCharacterLength)
 
         guard let currentKernValue = attribute(.kern, at: lastCharacterRange.location, effectiveRange: nil) else {
             return
@@ -290,7 +291,8 @@ extension NSMutableAttributedString {
             return
         }
 
-        let lastCharacterRange = NSRange(location: length - 1, length: 1)
+        let lastCharacterLength = string.suffix(1).utf16.count
+        let lastCharacterRange = NSRange(location: length - lastCharacterLength, length: lastCharacterLength)
 
         guard let currentKernValue = attribute(.bonMotRemovedKernAttribute, at: lastCharacterRange.location, effectiveRange: nil) else {
             return

--- a/Tests/ComposableTests.swift
+++ b/Tests/ComposableTests.swift
@@ -213,23 +213,22 @@ class ComposableTests: XCTestCase {
     func testKerningStrippingOnLastCharacter() {
         let styleWithTracking = StringStyle(.tracking(.point(0.5)))
 
-        let testCases: [String] = [
-            "abc",
-            "abc🍕",
-            "🍕🍕",
+        let pairsline = #line; let testCases: [(input: String, lastCharacterUnicodeLength: Int)] = [
+            ("abc", 1),
+            ("abc🍕", 2),
+            ("🍕🍕", 2),
         ]
 
-        for testCase in testCases {
-            let styledString = testCase.styled(with: styleWithTracking)
+        for (offset, testCase) in testCases.enumerated() {
+            let styledString = testCase.input.styled(with: styleWithTracking)
 
             var range = NSRange(location: 0, length: 0)
             let maxRange = NSRange(location: 0, length: styledString.length)
 
             let kerning = styledString.attribute(.kern, at: 0, longestEffectiveRange: &range, in: maxRange) as? Float
-
-            let lastCharacterUnicodeLength = testCase.suffix(1).utf16.count
-            XCTAssertEqual(kerning, 0.5)
-            XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - lastCharacterUnicodeLength))
+            let lineNumber = pairsline + offset + 1
+            XCTAssertEqual(kerning, 0.5, line: UInt(lineNumber))
+            XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - testCase.lastCharacterUnicodeLength), line: UInt(lineNumber))
         }
     }
 }

--- a/Tests/ComposableTests.swift
+++ b/Tests/ComposableTests.swift
@@ -226,9 +226,9 @@ class ComposableTests: XCTestCase {
             let maxRange = NSRange(location: 0, length: styledString.length)
 
             let kerning = styledString.attribute(.kern, at: 0, longestEffectiveRange: &range, in: maxRange) as? Float
-            let lineNumber = pairsline + offset + 1
-            XCTAssertEqual(kerning, 0.5, line: UInt(lineNumber))
-            XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - testCase.lastCharacterUnicodeLength), line: UInt(lineNumber))
+            let testLine = UInt(pairsline + offset + 1)
+            XCTAssertEqual(kerning, 0.5, line: testLine)
+            XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - testCase.lastCharacterUnicodeLength), line: testLine)
         }
     }
 }

--- a/Tests/ComposableTests.swift
+++ b/Tests/ComposableTests.swift
@@ -210,4 +210,26 @@ class ComposableTests: XCTestCase {
         XCTAssertEqual(["a", "b", "c"].joined() as NSAttributedString, "abc".styled(with: StringStyle()))
     }
 
+    func testKerningStrippingOnLastCharacter() {
+        let styleWithTracking = StringStyle(.tracking(.point(0.5)))
+
+        let testCases: [String] = [
+            "abc",
+            "abc🍕",
+            "🍕🍕",
+        ]
+
+        for testCase in testCases {
+            let styledString = testCase.styled(with: styleWithTracking)
+
+            var range = NSRange(location: 0, length: 0)
+            let maxRange = NSRange(location: 0, length: styledString.length)
+
+            let kerning = styledString.attribute(.kern, at: 0, longestEffectiveRange: &range, in: maxRange) as? Float
+
+            let lastCharacterUnicodeLength = testCase.suffix(1).utf16.count
+            XCTAssertEqual(kerning, 0.5)
+            XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - lastCharacterUnicodeLength))
+        }
+    }
 }


### PR DESCRIPTION
The current implementation of `removeKerningFromLastCharacter` and `restoreKerningOnLastCharacter` start from the assumption that the last character range always has length 1. This however is not true for more complex characters, such as emojis.
The consequence of this was a bug in which applying a style to a string that ended with an emoji, while keeping the flag `stripTrailingKerning` to its default value of `true`, would result in the emoji not being shown at all.