### PR TITLE
Stop exporting table view compatibility alias

### DIFF
--- a/Example-iOS/StyleViewController.swift
+++ b/Example-iOS/StyleViewController.swift
@@ -42,7 +42,11 @@ class StyleViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.rowHeight = UITableView.automaticDimension
+        #if swift(>=4.2)
+            tableView.rowHeight = UITableView.automaticDimension
+        #else
+            tableView.rowHeight = UITableViewAutomaticDimension
+        #endif
         tableView.estimatedRowHeight = 50
     }
 

--- a/Sources/Compatibility.swift
+++ b/Sources/Compatibility.swift
@@ -102,12 +102,6 @@
 
             }
 
-            extension UITableView {
-
-                public static let automaticDimension = UITableViewAutomaticDimension
-
-            }
-
         #endif
     #endif
 #endif


### PR DESCRIPTION
This was never supposed to be public. It’s _techinically_ a breaking change for anyone depending on this behavior, but since updating BonMot requires a recompile anyway, I’m fine with just shipping this as a bug fix.