### PR TITLE
New XMLStyleRule variants for dynamic styling

### DIFF
--- a/Sources/XMLBuilder.swift
+++ b/Sources/XMLBuilder.swift
@@ -116,11 +116,21 @@ public enum XMLStyleRule {
     /// A name/style pairing.
     case style(String, StringStyle)
 
+    /// A name with a block that returns style based on `attributes` dictionary.
+    case styleBlock(String, ([String: String]) -> StringStyle)
+
     /// A `Composable` to insert before entering tags whose name equals `element`.
     case enter(element: String, insert: Composable)
 
+    /// A block that returns `Composable` to insert before entering tags whose name equals `element`, based on
+    /// `attributes` dictionary.
+    case enterBlock(element: String, insert: ([String: String]) -> Composable)
+
     /// A `Composable` to insert before exiting tags whose name equals `element`.
     case exit(element: String, insert: Composable)
+
+    /// A block that returns `Composable` to insert before exiting tags whose name equals `element`.
+    case exitBlock(element: String, insert: () -> Composable)
 
     /// An `XMLStyler` implementation for handling `XMLStyleRule`s.
     struct Styler: XMLStyler {
@@ -132,6 +142,8 @@ public enum XMLStyleRule {
                 switch rule {
                 case let .style(string, style) where string == name:
                     return style
+                case let .styleBlock(string, block) where string == name:
+                    return block(attributes)
                 default:
                     break
                 }
@@ -149,6 +161,8 @@ public enum XMLStyleRule {
                 switch rule {
                 case let .enter(string, composable) where string == name:
                     return composable
+                case let .enterBlock(string, block) where string == name:
+                    return block(attributes)
                 default: break
                 }
             }
@@ -160,6 +174,8 @@ public enum XMLStyleRule {
                 switch rule {
                 case let .exit(string, composable) where string == name:
                     return composable
+                case let .exitBlock(string, block) where string == name:
+                    return block()
                 default: break
                 }
             }

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -563,22 +563,14 @@ class StringStyleTests: XCTestCase {
 
         let rules: [XMLStyleRule] = [
             .styleBlock("one") { attributes in
-                guard let val1 = attributes["attr1"], let intVal1 = Int(val1) else {
-                    XCTFail("attr1 not found")
-                    return StringStyle()
-                }
+                tagAttr1Value = attributes["attr1"]
 
-                tagAttr1Value = val1
-                return StringStyle(.baselineOffset(CGFloat(intVal1)))
+                return StringStyle(.baselineOffset(CGFloat(Int(tagAttr1Value ?? "") ?? 0)))
             },
             .styleBlock("two") { attributes in
-                guard let val2 = attributes["attr2"], let intVal2 = Int(val2) else {
-                    XCTFail("attr2 not found")
-                    return StringStyle()
-                }
+                tagAttr2Value = attributes["attr2"]
 
-                tagAttr2Value = val2
-                return StringStyle(.baselineOffset(CGFloat(intVal2)))
+                return StringStyle(.baselineOffset(CGFloat(Int(tagAttr2Value ?? "") ?? 0)))
             },
         ]
 
@@ -614,39 +606,19 @@ class StringStyleTests: XCTestCase {
 
         let rules: [XMLStyleRule] = [
             .enterBlock(element: "one") { attributes in
-                guard let val1 = attributes["attr1"], let intVal1 = Int(val1) else {
-                    XCTFail("attr1 not found")
-                    return ""
-                }
+                tagAttr1Value = attributes["attr1"]
+                tagAttr2Value = attributes["attr2"]
 
-                guard let val2 = attributes["attr2"] else {
-                    XCTFail("attr2 not found")
-                    return ""
-                }
-
-                tagAttr1Value = val1
-                tagAttr2Value = val2
-
-                return val2.styled(with: .baselineOffset(CGFloat(intVal1)))
+                return (tagAttr2Value ?? "").styled(with: .baselineOffset(CGFloat(Int(tagAttr1Value ?? "") ?? 0)))
             },
             .exitBlock(element: "one") {
                 return "c"
             },
             .enterBlock(element: "two") { attributes in
-                guard let val3 = attributes["attr3"], let intVal3 = Int(val3) else {
-                    XCTFail("attr3 not found")
-                    return ""
-                }
+                tagAttr3Value = attributes["attr3"]
+                tagAttr4Value = attributes["attr4"]
 
-                guard let val4 = attributes["attr4"] else {
-                    XCTFail("attr4 not found")
-                    return ""
-                }
-
-                tagAttr3Value = val3
-                tagAttr4Value = val4
-
-                return val4.styled(with: .baselineOffset(CGFloat(intVal3)))
+                return (tagAttr4Value ?? "").styled(with: .baselineOffset(CGFloat(Int(tagAttr3Value ?? "") ?? 0)))
             },
             .exitBlock(element: "two") {
                 return "d"

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -555,11 +555,11 @@ class StringStyleTests: XCTestCase {
         XCTAssertFalse(stillHasAltSixDict)
     }
 
-    func testStyleBlockRules() {
-        let string = "0<one attr1=\"11\">1<two attr2=\"12\">2</two></one>"
+    func testStyleBlockRules() throws {
+        let string = #"0<one attr1="11">1<two attr2="12">2</two></one>"#
 
-        var tagAttr1Value: String!
-        var tagAttr2Value: String!
+        var tagAttr1Value: String?
+        var tagAttr2Value: String?
 
         let rules: [XMLStyleRule] = [
             .styleBlock("one") { attributes in
@@ -592,25 +592,25 @@ class StringStyleTests: XCTestCase {
         let attrs1 = attributed.attributes(at: 1, effectiveRange: nil)
         let attrs2 = attributed.attributes(at: 2, effectiveRange: nil)
 
-        XCTAssertTrue(attrs0.count == 1)
-        XCTAssertTrue(attrs1.count == 2)
-        XCTAssertTrue(attrs2.count == 2)
+        XCTAssertEqual(attrs0.count, 1)
+        XCTAssertEqual(attrs1.count, 2)
+        XCTAssertEqual(attrs2.count, 2)
 
         XCTAssertNil(attrs0[.baselineOffset])
-        guard let lineSpacing1 = attrs1[.baselineOffset] as? Int else { XCTFail("lineSpacing1 not found"); return }
-        guard let lineSpacing2 = attrs2[.baselineOffset] as? Int else { XCTFail("lineSpacing2 not found"); return }
+        let lineSpacing1 = try XCTUnwrap(attrs1[.baselineOffset] as? Int)
+        let lineSpacing2 = try XCTUnwrap(attrs2[.baselineOffset] as? Int)
 
         XCTAssertEqual(lineSpacing1, 11)
         XCTAssertEqual(lineSpacing2, 12)
     }
 
-    func testEnterExitBlockRules() {
-        let string = "0<one attr1=\"11\" attr2=\"a\">1<two attr3=\"12\" attr4=\"b\">2</two></one>"
+    func testEnterExitBlockRules() throws {
+        let string = #"0<one attr1="11" attr2="a">1<two attr3="12" attr4="b">2</two></one>"#
 
-        var tagAttr1Value: String!
-        var tagAttr2Value: String!
-        var tagAttr3Value: String!
-        var tagAttr4Value: String!
+        var tagAttr1Value: String?
+        var tagAttr2Value: String?
+        var tagAttr3Value: String?
+        var tagAttr4Value: String?
 
         let rules: [XMLStyleRule] = [
             .enterBlock(element: "one") { attributes in
@@ -667,16 +667,16 @@ class StringStyleTests: XCTestCase {
         let attrs3 = attributed.attributes(at: 3, effectiveRange: nil)
         let attrs4 = attributed.attributes(at: 4, effectiveRange: nil)
 
-        XCTAssertTrue(attrs0.count == 1)
-        XCTAssertTrue(attrs1.count == 2)
-        XCTAssertTrue(attrs2.count == 1)
-        XCTAssertTrue(attrs3.count == 2)
-        XCTAssertTrue(attrs4.count == 1)
+        XCTAssertEqual(attrs0.count, 1)
+        XCTAssertEqual(attrs1.count, 2)
+        XCTAssertEqual(attrs2.count, 1)
+        XCTAssertEqual(attrs3.count, 2)
+        XCTAssertEqual(attrs4.count, 1)
 
         XCTAssertNil(attrs0[.baselineOffset])
-        guard let lineSpacing1 = attrs1[.baselineOffset] as? Int else { XCTFail("lineSpacing1 not found"); return }
+        let lineSpacing1 = try XCTUnwrap(attrs1[.baselineOffset] as? Int)
         XCTAssertNil(attrs2[.baselineOffset])
-        guard let lineSpacing3 = attrs3[.baselineOffset] as? Int else { XCTFail("lineSpacing3 not found"); return }
+        let lineSpacing3 = try XCTUnwrap(attrs3[.baselineOffset] as? Int)
         XCTAssertNil(attrs4[.baselineOffset])
 
         XCTAssertEqual(lineSpacing1, 11)


### PR DESCRIPTION
Hello and thank you for this fine library!

I propose addition of several `XMLStyleRule`s to dynamically generate and apply styles, enter- and exit-insertions of elements.

With these changes, you can use them like this:

```swift
// We want to style an xml that contains tags with some important attributes

var quoteAuthorStack = [String]()

let attributedString = try NSAttributedString.composed(
    ofXML: rawXml,
    rules: [
        .style("quote", quoteStyle),

        // We want to insert an image with a beautiful quote before the actual quote text.
        // Also we have an author's name in "author" attribute and we want 
        // to append this name after the quote text.
        .enterBlock(element: "quote") { attributes in
            // Saving author's name for later use
            quoteAuthorStack.append(attributes["author"]!)

            // "author" handling was hacky, so to show `attributes` in action,
            // why don't we have different quote images for different occasions...
            return NSAttributedString.composed(of: [ 
                UIImage(named: attributes["quotestyle"]!)!, 
                Special.lineFeed 
            ])
        },
        
        .exitBlock(element: "quote") {
            // Using our saved "author" attribute here to append the name after the quote
            let author = quoteAuthorStack.popLast()!

            return NSAttributedString.composed(of: [ 
                Special.lineFeed, author.styled(with: authorStyle) 
            ])
        },

        // Also we have a "link" tag with some attributes that will help us
        // to generate an URL
        .styleBlock("link") { attributes in
            guard let type = attributes["type"], [ "event", "person" ].contains(type),
                let id = attributes["id"],
                let link = URL(string: "\(Const.Domain)/\(type)/\(id)") else { return defaultStyle }

            return defaultStyle.byAdding(.link(link))
        }
    ]
)
```

We have a BonMot patched with these changes for quite some time, they are very convenient for us :)