### PR TITLE
Simplify StringStyle.update(part:) switch statement

### DIFF
--- a/BonMot.podspec
+++ b/BonMot.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name             = "BonMot"
   s.version          = "5.6.0"
   s.summary          = "Beautiful, easy attributed strings in Swift"
-  s.swift_versions    = ["4.0", "4.2", "5.0"]
+  s.swift_versions    = ["4.2", "5.0"]
   s.description      = <<-DESC
   BonMot removes all the mystery from creating beautiful, powerful attributed strings in Swift.
                        DESC

--- a/Sources/StringStyle+Part.swift
+++ b/Sources/StringStyle+Part.swift
@@ -219,81 +219,52 @@ extension StringStyle {
             self.add(stringStyle: style)
         case let .emphasis(emphasis):
             self.emphasis = emphasis
-        default:
-            // interaction between `#if` and `switch` is disappointing. This case
-            // is in `default:` to remove a warning that default won't be accessed
-            // on some platforms.
-            switch stylePart {
-            case let .hyphenationFactor(hyphenationFactor):
-                self.hyphenationFactor = hyphenationFactor
-            default:
-                #if os(iOS) || os(tvOS) || os(watchOS)
-                    switch stylePart {
-                    case let .speaksPunctuation(speaksPunctuation):
-                        self.speaksPunctuation = speaksPunctuation
-                        return
-                    case let .speakingLanguage(speakingLanguage):
-                        self.speakingLanguage = speakingLanguage
-                        return
-                    case let .speakingPitch(speakingPitch):
-                        self.speakingPitch = speakingPitch
-                        return
-                    case let .speakingPronunciation(speakingPronunciation):
-                        self.speakingPronunciation = speakingPronunciation
-                        return
-                    case let .shouldQueueSpeechAnnouncement(shouldQueueSpeechAnnouncement):
-                        self.shouldQueueSpeechAnnouncement = shouldQueueSpeechAnnouncement
-                        return
-                    case let .headingLevel(headingLevel):
-                        self.headingLevel = headingLevel
-                        return
-                    default:
-                        break
-                    }
-                #endif
-
-                #if os(OSX) || os(iOS) || os(tvOS)
-                    switch stylePart {
-                    case let .numberCase(numberCase):
-                        self.numberCase = numberCase
-                    case let .numberSpacing(numberSpacing):
-                        self.numberSpacing = numberSpacing
-                    case let .fractions(fractions):
-                        self.fractions = fractions
-                    case let .superscript(superscript):
-                        self.superscript = superscript
-                    case let .`subscript`(`subscript`):
-                        self.`subscript` = `subscript`
-                    case let .ordinals(ordinals):
-                        self.ordinals = ordinals
-                    case let .scientificInferiors(scientificInferiors):
-                        self.scientificInferiors = scientificInferiors
-                    case let .smallCaps(smallCaps):
-                        self.smallCaps.insert(smallCaps)
-                    case let .stylisticAlternates(stylisticAlternates):
-                        self.stylisticAlternates.add(other: stylisticAlternates)
-                    case let .contextualAlternates(contextualAlternates):
-                        self.contextualAlternates.add(other: contextualAlternates)
-                    case let .fontFeature(featureProvider):
-                        self.fontFeatureProviders.append(featureProvider)
-                    default:
-                        #if os(iOS) || os(tvOS)
-                            switch stylePart {
-                            case let .adapt(style):
-                                self.adaptations.append(style)
-                            case let .textStyle(textStyle):
-                                self.font = UIFont.bon_preferredFont(forTextStyle: textStyle, compatibleWith: nil)
-                            default:
-                                fatalError("StylePart \(stylePart) should have been caught by an earlier case.")
-                            }
-                        #else
-                            fatalError("StylePart \(stylePart) should have been caught by an earlier case.")
-                        #endif
-                    }
-                #else
-                    fatalError("StylePart \(stylePart) should have been caught by an earlier case.")
-                #endif
-            }
+        case let .hyphenationFactor(hyphenationFactor):
+            self.hyphenationFactor = hyphenationFactor
+        #if os(iOS) || os(tvOS) || os(watchOS)
+            case let .speaksPunctuation(speaksPunctuation):
+                self.speaksPunctuation = speaksPunctuation
+            case let .speakingLanguage(speakingLanguage):
+                self.speakingLanguage = speakingLanguage
+            case let .speakingPitch(speakingPitch):
+                self.speakingPitch = speakingPitch
+            case let .speakingPronunciation(speakingPronunciation):
+                self.speakingPronunciation = speakingPronunciation
+            case let .shouldQueueSpeechAnnouncement(shouldQueueSpeechAnnouncement):
+                self.shouldQueueSpeechAnnouncement = shouldQueueSpeechAnnouncement
+            case let .headingLevel(headingLevel):
+                self.headingLevel = headingLevel
+        #endif
+        #if os(OSX) || os(iOS) || os(tvOS)
+            case let .numberCase(numberCase):
+                self.numberCase = numberCase
+            case let .numberSpacing(numberSpacing):
+                self.numberSpacing = numberSpacing
+            case let .fractions(fractions):
+                self.fractions = fractions
+            case let .superscript(superscript):
+                self.superscript = superscript
+            case let .`subscript`(`subscript`):
+                self.`subscript` = `subscript`
+            case let .ordinals(ordinals):
+                self.ordinals = ordinals
+            case let .scientificInferiors(scientificInferiors):
+                self.scientificInferiors = scientificInferiors
+            case let .smallCaps(smallCaps):
+                self.smallCaps.insert(smallCaps)
+            case let .stylisticAlternates(stylisticAlternates):
+                self.stylisticAlternates.add(other: stylisticAlternates)
+            case let .contextualAlternates(contextualAlternates):
+                self.contextualAlternates.add(other: contextualAlternates)
+            case let .fontFeature(featureProvider):
+                self.fontFeatureProviders.append(featureProvider)
+        #endif
+        #if os(iOS) || os(tvOS)
+            case let .adapt(style):
+                self.adaptations.append(style)
+            case let .textStyle(textStyle):
+                self.font = UIFont.bon_preferredFont(forTextStyle: textStyle, compatibleWith: nil)
+        #endif
         }
     }
     //swiftlint:enable function_body_length


### PR DESCRIPTION
Follow-up to #381 because GitHub won’t let me reopen it. Fixes #345.

Simplifies the `switch` statement in `StringStyle.update(part:)` using the improved interaction between switch and #if in Swift 4.1+. This requires removing Swift 4.0 from the supported versions. I think it’s better not to add new support for Swift 4.1, so that would make the minimum version Swift 4.2.