### PR TITLE
Test cleanup and typo fixes

### DIFF
--- a/Example-iOS/DemoStrings.swift
+++ b/Example-iOS/DemoStrings.swift
@@ -232,7 +232,7 @@ enum DemoStrings {
             let xml = "<li>This list is defined with XML and displayed in a single <code>UILabel</code>.</li><li>Each row is represented with an <code>&lt;li&gt;</code> tag.</li><li>Attributed strings define the string to use for bullets.</li><li>The text style is also specified for the <code>&lt;li&gt;</code> and <code>&lt;code&gt;</code> tags.</li>"
 
             // Use this method of parsing XML if the content is not under your
-            // control, since you are less likley to catch edge cases while
+            // control, since you are less likely to catch edge cases while
             // developing. This way, you can handle parsing errors gracefully.
             guard let string = try? NSAttributedString.composed(ofXML: xml, rules: rules) else {
                 fatalError("Unable to load XML \(xml)")
@@ -285,10 +285,10 @@ enum DemoStrings {
     /// Demonstrate specifying Dynamic Type sizing behavior and custom styles
     /// via IBDesignable in Interface Builder. To see this example in action,
     /// play with the iOS Text Size slider and see how the UI elements react.
-    static let dynamcTypeUIKitExample = DemoStrings.customStoryboard(identifier: "CatalogViewController")
+    static let dynamicTypeUIKitExample = DemoStrings.customStoryboard(identifier: "CatalogViewController")
         .attributedString(from: "Dynamic UIKit elements with custom fonts")
 
-    /// Demonstrate how BonMot interacts with sytem preferred text styles.
+    /// Demonstrate how BonMot interacts with system preferred text styles.
     static let preferredFontsExample = DemoStrings.customStoryboard(identifier: "PreferredFonts")
         .attributedString(from: "Preferred Fonts")
 

--- a/Example-iOS/StyleViewController.swift
+++ b/Example-iOS/StyleViewController.swift
@@ -29,7 +29,7 @@ class StyleViewController: UITableViewController {
         ("Baseline Offset", [DemoStrings.heartsExample]),
         ("Indentation", DemoStrings.indentationExamples),
         ("Advanced XML and Kerning", [DemoStrings.advancedXMLAndKerningExample]),
-        ("Dynamic Type", [DemoStrings.dynamcTypeUIKitExample, DemoStrings.preferredFontsExample]),
+        ("Dynamic Type", [DemoStrings.dynamicTypeUIKitExample, DemoStrings.preferredFontsExample]),
         ("OpenType Features", [
             DemoStrings.figureStylesExample,
             DemoStrings.ordinalsExample,

--- a/Sources/Composable.swift
+++ b/Sources/Composable.swift
@@ -25,7 +25,7 @@ public protocol Composable {
     /// - Parameters:
     ///   - attributedString: The attributed string to which to append the
     ///                       receiver.
-    ///   - baseStyle: Additional attribues to apply to the receiver before
+    ///   - baseStyle: Additional attributes to apply to the receiver before
     ///                appending it to the passed attributed string.
     func append(to attributedString: NSMutableAttributedString, baseStyle: StringStyle)
 
@@ -38,7 +38,7 @@ public protocol Composable {
     /// - Parameters:
     ///   - attributedString: The attributed string to which to append the
     ///                       receiver.
-    ///   - baseStyle: Additional attribues to apply to the receiver before
+    ///   - baseStyle: Additional attributes to apply to the receiver before
     ///                appending it to the passed attributed string.
     ///   - isLastElement: Whether the receiver is the final element that is
     ///                    being appended to an attributed string. Used in cases

--- a/Sources/FontFeatures.swift
+++ b/Sources/FontFeatures.swift
@@ -91,7 +91,7 @@
         /// will line up when arranged in columns.
         case monospaced
 
-        /// Proportionally spaced numbers, also known as "proprotional figures",
+        /// Proportionally spaced numbers, also known as "proportional figures",
         /// are of variable width. This makes them look better in most cases,
         /// but they should be avoided when numbers need to line up in columns.
         case proportional
@@ -115,12 +115,12 @@
 
         /// Diagonal Fractions, when written on paper, are written on one line
         /// with the numerator diagonally above and to the left of the
-        /// demoninator, with the slash ("/") between them.
+        /// denominator, with the slash ("/") between them.
         case diagonal
 
         /// Vertical Fractions, when written on paper, are written on one line
         /// with the numerator directly above the
-        /// demoninator, with a line lying horizontally between them.
+        /// denominator, with a line lying horizontally between them.
         case vertical
 
         public func featureSettings() -> [(type: Int, selector: Int)] {
@@ -143,7 +143,7 @@
         /// No vertical position adjustment is applied.
         case normal
 
-        /// Superscript (superior) glpyh variants are used, as in footnotes¹.
+        /// Superscript (superior) glyph variants are used, as in footnotes¹.
         case superscript
 
         /// Subscript (inferior) glyph variants are used: vₑ.

--- a/Sources/Tab.swift
+++ b/Sources/Tab.swift
@@ -64,7 +64,7 @@ extension Tab {
         let string = attributedString.string as NSString
 
         // Lookup the range this paragraph is operating on.
-        // This is the range from `range` to the preceeding newline or the start of the string.
+        // This is the range from `range` to the preceding newline or the start of the string.
         let precedingRange = NSRange(location: 0, length: NSMaxRange(range))
         var leadingNewline = string.rangeOfCharacter(from: CharacterSet.newlines, options: [.backwards], range: precedingRange).location
         leadingNewline = (leadingNewline == NSNotFound) ? 0 : leadingNewline + 1

--- a/Sources/UIKit/AdaptableTextContainer.swift
+++ b/Sources/UIKit/AdaptableTextContainer.swift
@@ -218,7 +218,7 @@ extension UIToolbar {
 // MARK: - AdaptableTextContainer for UIViewController
 extension UIViewController {
 
-    /// Adapt the attributed text of teh bar items in the navigation item or in
+    /// Adapt the attributed text of the bar items in the navigation item or in
     /// the toolbar to the specified trait collection.
     ///
     /// - parameter traitCollection: The new trait collection.
@@ -246,7 +246,7 @@ extension UIBarItem {
     /// Adapt `titleTextAttributes` to the specified trait collection.
     ///
     /// - note: This extension does not conform to `AdaptableTextContainer`
-    /// because `UIBarIterm` is not a view or view controller.
+    /// because `UIBarItem` is not a view or view controller.
     /// - parameter traitCollection: the new trait collection.
     @objc(bon_updateTextForTraitCollection:)
     public func adaptText(forTraitCollection traitCollection: UITraitCollection) {

--- a/Sources/UIKit/AdaptiveStyle.swift
+++ b/Sources/UIKit/AdaptiveStyle.swift
@@ -131,12 +131,12 @@ extension AdaptiveStyle {
     /// - Parameters:
     ///   - size: The size the font was designed for at `UIContentSizeCategory.large`.
     ///   - contentSizeCategory: The content size category to scale to.
-    ///   - minimiumSize: The smallest size the font can be. Defaults to 11, or
+    ///   - minimumSize: The smallest size the font can be. Defaults to 11, or
     ///                   `designatedSize` if `designatedSize` is less than 11.
     /// - Returns: The new point size, scaled to the specified content size
-    public static func adapt(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimiumSize: CGFloat = 11) -> CGFloat {
+    public static func adapt(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimumSize: CGFloat = 11) -> CGFloat {
         let shift = min(shiftTable[contentSizeCategory] ?? 0, CGFloat(6))
-        let minSize = min(minimiumSize, size)
+        let minSize = min(minimumSize, size)
         return max(size + shift, minSize)
     }
 
@@ -146,14 +146,52 @@ extension AdaptiveStyle {
     /// - Parameters:
     ///   - size: The size the font was designed for at `UIContentSizeCategory.large`.
     ///   - contentSizeCategory: The content size category to scale to.
-    ///   - minimiumSize: The smallest size the font can be. Defaults to 11.
+    ///   - minimumSize: The smallest size the font can be. Defaults to 11.
     /// - Returns: The new point size, scaled to the specified contentSize.
-    public static func adaptBody(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimiumSize: CGFloat = 11) -> CGFloat {
+    public static func adaptBody(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimumSize: CGFloat = 11) -> CGFloat {
         let shift = shiftTable[contentSizeCategory] ?? 0
-        let minSize = min(minimiumSize, size)
+        let minSize = min(minimumSize, size)
         return max(size + shift, minSize)
     }
 
+}
+
+extension AdaptiveStyle { // Deprecated - search the code and remove other deprecations when you remove this
+
+    /// The default scaling function. Grows by 2 points for each
+    /// step above Large, and shrinks by 1 point for each step below Large.
+    /// This function does not create larger values for content size category
+    /// values in the Accessibility range of content size categories.
+    ///
+    /// - Parameters:
+    ///   - size: The size the font was designed for at `UIContentSizeCategory.large`.
+    ///   - contentSizeCategory: The content size category to scale to.
+    ///   - minimiumSize: The smallest size the font can be. Defaults to `designatedSize` if `designatedSize` is less
+    ///                   than the supplied size.
+    /// - Returns: The new point size, scaled to the specified content size
+    @available(*, deprecated, renamed: "adapt(designatedSize:for:minimumSize:)")
+    public static func adapt(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimiumSize minimumSize: CGFloat) -> CGFloat {
+        // removed default value of minimiumSize so that call sites that don't pass anything will use the new implementation
+        let shift = min(shiftTable[contentSizeCategory] ?? 0, CGFloat(6))
+        let minSize = min(minimumSize, size)
+        return max(size + shift, minSize)
+    }
+
+    /// A scaling function for "body" elements. Continues to grow for content
+    /// size category values in the Accessibility range.
+    ///
+    /// - Parameters:
+    ///   - size: The size the font was designed for at `UIContentSizeCategory.large`.
+    ///   - contentSizeCategory: The content size category to scale to.
+    ///   - minimiumSize: The smallest size the font can be.
+    /// - Returns: The new point size, scaled to the specified contentSize.
+    @available(*, deprecated, renamed: "adaptBody(designatedSize:for:minimumSize:)")
+    public static func adaptBody(designatedSize size: CGFloat, for contentSizeCategory: BonMotContentSizeCategory, minimiumSize minimumSize: CGFloat) -> CGFloat {
+        // removed default value of minimiumSize so that call sites that don't pass anything will use the new implementation
+        let shift = shiftTable[contentSizeCategory] ?? 0
+        let minSize = min(minimumSize, size)
+        return max(size + shift, minSize)
+    }
 }
 
 extension AdaptiveStyle: EmbeddedTransformation {

--- a/Sources/UIKit/AttributedStringTransformation.swift
+++ b/Sources/UIKit/AttributedStringTransformation.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Defines a transformation to be performed on an `NSMutableAttributedString`.
-/// It is used for adative transformations that need to know about the content
+/// It is used for adaptive transformations that need to know about the content
 /// of the string in order to be performed. These are applied after the
 /// `AdaptiveStyleTransformation`s are applied.
 internal protocol AttributedStringTransformation {

--- a/Sources/UIKit/NSAttributedString+Adaptive.swift
+++ b/Sources/UIKit/NSAttributedString+Adaptive.swift
@@ -18,7 +18,7 @@ extension NSAttributedString {
     /// - Parameters:
     ///   - theAttributes: The attributes to transform.
     ///   - traitCollection: The trait collection to which to adapt the attributes.
-    /// - Returns: Attributes with fonts updated to the specified contect size category.
+    /// - Returns: Attributes with fonts updated to the specified content size category.
     public static func adapt(attributes theAttributes: StyleAttributes, to traitCollection: UITraitCollection) -> StyleAttributes {
         let adaptations: [AdaptiveStyleTransformation] = EmbeddedTransformationHelpers.transformations(from: theAttributes)
         var styleAttributes = theAttributes

--- a/Sources/UIKit/NSAttributedString+Adaptive.swift
+++ b/Sources/UIKit/NSAttributedString+Adaptive.swift
@@ -73,7 +73,9 @@ extension StringStyle {
 // MARK: - Deprecations
 extension NSAttributedString {
 
-    @available(*, deprecated, renamed: "adapted(to:)") public final func adapt(to traitCollection: UITraitCollection) -> NSAttributedString {
+    // Deprecated - search the code and remove other deprecations when you remove this
+    @available(*, deprecated, renamed: "adapted(to:)")
+    public final func adapt(to traitCollection: UITraitCollection) -> NSAttributedString {
         return adapted(to: traitCollection)
     }
 

--- a/Sources/UIKit/StyleableUIElement.swift
+++ b/Sources/UIKit/StyleableUIElement.swift
@@ -125,7 +125,7 @@ extension UITextView {
 
     /// A string style. Stored via associated objects.
     /// - note: The style is applied to both the `attributedText` and
-    /// `typingAtributes`. If you plan on styling them differently, use
+    /// `typingAttributes`. If you plan on styling them differently, use
     /// attributed strings directly.
     public final var bonMotStyle: StringStyle? {
         get { return StyleableUIElementHelpers.getAssociatedStyle(from: self) }

--- a/Sources/XMLBuilder.swift
+++ b/Sources/XMLBuilder.swift
@@ -33,7 +33,7 @@ extension NSAttributedString {
     ///                specify styling options.
     ///   - styler: An optional custom styler to perform extra style operations.
     ///   - options: XML parsing options.
-    /// - Returns: A styled attriubted string.
+    /// - Returns: A styled attriubuted string.
     /// - Throws: Any errors encountered by the XML parser.
     public static func composed(ofXML fragment: String, baseStyle: StringStyle? = nil, styler: XMLStyler? = nil, options: XMLParsingOptions = []) throws -> NSAttributedString {
         let builder = XMLBuilder(

--- a/Tests/AdaptiveStyleTests.swift
+++ b/Tests/AdaptiveStyleTests.swift
@@ -10,7 +10,7 @@
 import UIKit
 import XCTest
 
-#if swift(>=2.3) && os(iOS)
+#if os(iOS)
 
 @available(iOS 10.0, *)
 let defaultTraitCollection = UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.large)

--- a/Tests/AdaptiveStyleTests.swift
+++ b/Tests/AdaptiveStyleTests.swift
@@ -28,13 +28,13 @@ class AdaptiveStyleTests: XCTestCase {
             let traitCollection = UITraitCollection(preferredContentSizeCategory: contentSizeCategory)
             return NSAttributedString.adapt(attributes: style.attributes, to: traitCollection)
         }
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 30)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 32)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 34)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 30)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 32)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 34)
 
         // Ensure the accessibility ranges are capped at XXXL
         let sizes = [
@@ -45,7 +45,7 @@ class AdaptiveStyleTests: XCTestCase {
             UIContentSizeCategory.accessibilityExtraExtraExtraLarge,
             ]
         for size in sizes {
-            BONAssert(attributes: testAttributes(size), query: { $0.pointSize }, float: 34)
+            BONAssert(attributes: testAttributes(size), query: \.pointSize, float: 34)
         }
     }
 
@@ -57,20 +57,20 @@ class AdaptiveStyleTests: XCTestCase {
             let attributes = style.attributes
             return NSAttributedString.adapt(attributes: attributes, to: traitCollection)
         }
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 30)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 32)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 34)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 30)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 32)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 34)
 
         // Ensure body keeps growing
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityMedium), query: { $0.pointSize }, float: 39)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityLarge), query: { $0.pointSize }, float: 44)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraLarge), query: { $0.pointSize }, float: 51)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraExtraLarge), query: { $0.pointSize }, float: 58)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraExtraExtraLarge), query: { $0.pointSize }, float: 64)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityMedium), query: \.pointSize, float: 39)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityLarge), query: \.pointSize, float: 44)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraLarge), query: \.pointSize, float: 51)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraExtraLarge), query: \.pointSize, float: 58)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.accessibilityExtraExtraExtraLarge), query: \.pointSize, float: 64)
     }
 
     func testPreferredFontDoesNotAdapt() {
@@ -81,8 +81,8 @@ class AdaptiveStyleTests: XCTestCase {
             return NSAttributedString.adapt(attributes: style.attributes, to: traitCollection)
         }
         // Ensure the font doesn't change sizes since it was added to the chain as a font, and `.preferred` was not added.
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: font.pointSize)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: font.pointSize)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: font.pointSize)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: font.pointSize)
     }
 
     func testTextStyleAdapt() {
@@ -97,22 +97,22 @@ class AdaptiveStyleTests: XCTestCase {
         if UIDevice.current.userInterfaceIdiom == .phone,
             UIScreen.main.bounds.height == 568,
             ProcessInfo().operatingSystemVersion.majorVersion >= 11 {
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 27)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 28)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 30)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 27)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 28)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 30)
         }
         else {
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 30)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 32)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 34)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 30)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 32)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 34)
         }
     }
 
@@ -129,22 +129,22 @@ class AdaptiveStyleTests: XCTestCase {
         if UIDevice.current.userInterfaceIdiom == .phone,
             UIScreen.main.bounds.height == 568,
             ProcessInfo().operatingSystemVersion.majorVersion >= 11 {
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 27)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 28)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 30)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 27)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 28)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 30)
         }
         else {
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 25)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 26)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 30)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 32)
-            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 34)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 25)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 26)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 30)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 32)
+            BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 34)
         }
     }
 
@@ -165,13 +165,13 @@ class AdaptiveStyleTests: XCTestCase {
             return NSAttributedString.adapt(attributes: style.attributes, to: traitCollection)
         }
 
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 24)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 25)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 31)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 33)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 37)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 24)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 25)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 31)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 33)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 37)
     }
 
     @available(iOS 11, *)
@@ -191,13 +191,13 @@ class AdaptiveStyleTests: XCTestCase {
             return NSAttributedString.adapt(attributes: style.attributes, to: traitCollection)
         }
 
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: { $0.pointSize }, float: 24)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: { $0.pointSize }, float: 25)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: { $0.pointSize }, float: 27)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: { $0.pointSize }, float: 28)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: { $0.pointSize }, float: 30)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: { $0.pointSize }, float: 30)
-        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: { $0.pointSize }, float: 30)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraSmall), query: \.pointSize, float: 24)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.small), query: \.pointSize, float: 25)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.medium), query: \.pointSize, float: 27)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.large), query: \.pointSize, float: 28)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraLarge), query: \.pointSize, float: 30)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraLarge), query: \.pointSize, float: 30)
+        BONAssert(attributes: testAttributes(UIContentSizeCategory.extraExtraExtraLarge), query: \.pointSize, float: 30)
     }
 
     func testAdobeAdaptiveTracking() {

--- a/Tests/AssertHelpers.swift
+++ b/Tests/AssertHelpers.swift
@@ -48,15 +48,15 @@ func BONAssertColor(inAttributes dictionary: StyleAttributes?, key: NSAttributed
     XCTAssertEqual(testComps.a, controlComps.a, accuracy: 0.0001)
 }
 
-func BONAssert(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, float: CGFloat, accuracy: CGFloat, file: StaticString = #file, line: UInt = #line) {
-    guard let dictionaryValue = dictionary?[key] as? CGFloat else {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, float: T, accuracy: T, file: StaticString = #file, line: UInt = #line) where T: FloatingPoint {
+    guard let dictionaryValue = dictionary?[key] as? T else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
     }
     XCTAssertEqual(dictionaryValue, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert(attributes dictionary: StyleAttributes?, query: (BONFont) -> CGFloat, float: CGFloat, accuracy: CGFloat = 0.001, file: StaticString = #file, line: UInt = #line) {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (BONFont) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #file, line: UInt = #line) where T: BinaryFloatingPoint {
     guard let font = dictionary?[.font] as? BONFont else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -65,7 +65,7 @@ func BONAssert(attributes dictionary: StyleAttributes?, query: (BONFont) -> CGFl
     XCTAssertEqual(value, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> CGFloat, float: CGFloat, accuracy: CGFloat, file: StaticString = #file, line: UInt = #line) {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #file, line: UInt = #line) where T: BinaryFloatingPoint {
     guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -74,31 +74,13 @@ func BONAssert(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle
     XCTAssertEqual(actualValue, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> Int, value: Int, file: StaticString = #file, line: UInt = #line) {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, value: T, file: StaticString = #file, line: UInt = #line) where T: Equatable {
     guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
     }
     let actualValue = query(paragraphStyle)
     XCTAssertEqual(value, actualValue, file: file, line: line)
-}
-
-func BONAssert(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> Bool, value: Bool, file: StaticString = #file, line: UInt = #line) {
-    guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
-        XCTFail("value is not of expected type", file: file, line: line)
-        return
-    }
-    let actualValue = query(paragraphStyle)
-    XCTAssertEqual(value, actualValue, file: file, line: line)
-}
-
-func BONAssert<T: RawRepresentable>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, value: T, file: StaticString = #file, line: UInt = #line) where T.RawValue: Equatable {
-    guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
-        XCTFail("value is not of expected type", file: file, line: line)
-        return
-    }
-    let actualValue = query(paragraphStyle)
-    XCTAssertEqual(value.rawValue, actualValue.rawValue, file: file, line: line)
 }
 
 func BONAssertEqualImages(_ image1: BONImage, _ image2: BONImage, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/AssertHelpers.swift
+++ b/Tests/AssertHelpers.swift
@@ -25,7 +25,7 @@ func dataFromImage(image theImage: BONImage) -> Data {
     #endif
 }
 
-func BONAssert<T: Equatable>(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, value: T, file: StaticString = #file, line: UInt = #line) {
+func BONAssert<T: Equatable>(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, value: T, file: StaticString = #filePath, line: UInt = #line) {
     guard let dictionaryValue = dictionary?[key] as? T else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -33,7 +33,7 @@ func BONAssert<T: Equatable>(attributes dictionary: StyleAttributes?, key: NSAtt
     XCTAssert(dictionaryValue == value, "\(key): \(dictionaryValue) != \(value)", file: file, line: line)
 }
 
-func BONAssertColor(inAttributes dictionary: StyleAttributes?, key: NSAttributedString.Key, color controlColor: BONColor, file: StaticString = #file, line: UInt = #line) {
+func BONAssertColor(inAttributes dictionary: StyleAttributes?, key: NSAttributedString.Key, color controlColor: BONColor, file: StaticString = #filePath, line: UInt = #line) {
     guard let testColor = dictionary?[key] as? BONColor else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -48,7 +48,7 @@ func BONAssertColor(inAttributes dictionary: StyleAttributes?, key: NSAttributed
     XCTAssertEqual(testComps.a, controlComps.a, accuracy: 0.0001)
 }
 
-func BONAssert<T>(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, float: T, accuracy: T, file: StaticString = #file, line: UInt = #line) where T: FloatingPoint {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, key: NSAttributedString.Key, float: T, accuracy: T, file: StaticString = #filePath, line: UInt = #line) where T: FloatingPoint {
     guard let dictionaryValue = dictionary?[key] as? T else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -56,7 +56,7 @@ func BONAssert<T>(attributes dictionary: StyleAttributes?, key: NSAttributedStri
     XCTAssertEqual(dictionaryValue, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (BONFont) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #file, line: UInt = #line) where T: BinaryFloatingPoint {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (BONFont) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #filePath, line: UInt = #line) where T: BinaryFloatingPoint {
     guard let font = dictionary?[.font] as? BONFont else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -65,7 +65,7 @@ func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (BONFont) -> T
     XCTAssertEqual(value, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #file, line: UInt = #line) where T: BinaryFloatingPoint {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, float: T, accuracy: T = T(0.001), file: StaticString = #filePath, line: UInt = #line) where T: BinaryFloatingPoint {
     guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -74,7 +74,7 @@ func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphSt
     XCTAssertEqual(actualValue, float, accuracy: accuracy, file: file, line: line)
 }
 
-func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, value: T, file: StaticString = #file, line: UInt = #line) where T: Equatable {
+func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphStyle) -> T, value: T, file: StaticString = #filePath, line: UInt = #line) where T: Equatable {
     guard let paragraphStyle = dictionary?[.paragraphStyle] as? NSParagraphStyle else {
         XCTFail("value is not of expected type", file: file, line: line)
         return
@@ -83,19 +83,19 @@ func BONAssert<T>(attributes dictionary: StyleAttributes?, query: (NSParagraphSt
     XCTAssertEqual(value, actualValue, file: file, line: line)
 }
 
-func BONAssertEqualImages(_ image1: BONImage, _ image2: BONImage, file: StaticString = #file, line: UInt = #line) {
+func BONAssertEqualImages(_ image1: BONImage, _ image2: BONImage, file: StaticString = #filePath, line: UInt = #line) {
     let data1 = dataFromImage(image: image1)
     let data2 = dataFromImage(image: image2)
     XCTAssertEqual(data1, data2, file: file, line: line)
 }
 
-func BONAssertNotEqualImages(_ image1: BONImage, _ image2: BONImage, file: StaticString = #file, line: UInt = #line) {
+func BONAssertNotEqualImages(_ image1: BONImage, _ image2: BONImage, file: StaticString = #filePath, line: UInt = #line) {
     let data1 = dataFromImage(image: image1)
     let data2 = dataFromImage(image: image2)
     XCTAssertNotEqual(data1, data2, file: file, line: line)
 }
 
-func BONAssertEqualFonts(_ font1: BONFont, _ font2: BONFont, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+func BONAssertEqualFonts(_ font1: BONFont, _ font2: BONFont, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
     let descriptor1 = font1.fontDescriptor
     let descriptor2 = font2.fontDescriptor
 

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -21,7 +21,7 @@ class StringStyleTests: XCTestCase {
 
     func testBasicAssertionUtilities() {
         let style = StringStyle(.font(.fontA), .color(.colorA), .backgroundColor(.colorB))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 3)
             // We're only checking the font name and point size, since the full style could have font
             // features that cause equality checks to fail. Font Feature support is tested in testFontFeatureStyle.
@@ -38,7 +38,7 @@ class StringStyleTests: XCTestCase {
     #if os(iOS) || os(tvOS)
     func testTextStyle() {
         let style = StringStyle(.textStyle(titleTextStyle))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? UIFont
             let fontTextStyle = font?.textStyle
@@ -51,7 +51,7 @@ class StringStyleTests: XCTestCase {
         let url = URL(string: "http://apple.com/")!
         let style = StringStyle(.link(url))
 
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: .link, value: url)
         }
@@ -59,7 +59,7 @@ class StringStyleTests: XCTestCase {
 
     func testStrikethroughStyle() {
         let style = StringStyle(.strikethrough(.byWord, .colorA))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 2)
             BONAssert(attributes: style.attributes, key: .strikethroughStyle, value: NSUnderlineStyle.byWord.rawValue)
             BONAssert(attributes: style.attributes, key: .strikethroughColor, value: BONColor.colorA)
@@ -68,7 +68,7 @@ class StringStyleTests: XCTestCase {
 
     func testUnderlineStyle() {
         let style = StringStyle(.underline(.byWord, .colorA))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 2)
             BONAssert(attributes: style.attributes, key: .underlineStyle, value: NSUnderlineStyle.byWord.rawValue)
             BONAssert(attributes: style.attributes, key: .underlineColor, value: BONColor.colorA)
@@ -77,7 +77,7 @@ class StringStyleTests: XCTestCase {
 
     func testBaselineStyle() {
         let style = StringStyle(.baselineOffset(15))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: .baselineOffset, float: CGFloat(15), accuracy: 0.001)
         }
@@ -85,7 +85,7 @@ class StringStyleTests: XCTestCase {
 
     func testLigatureStyle() {
         let style = StringStyle(.ligatures(.disabled))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: .ligature, value: 0)
         }
@@ -95,33 +95,33 @@ class StringStyleTests: XCTestCase {
 
     func testSpeaksPronunciationStyle() {
         let style = StringStyle(.speaksPunctuation(true))
-        for (style, fullstyle) in additiviePermutations(for: style) {
-            XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+        for (style, fullStyle) in additivePermutations(for: style) {
+            XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: .accessibilitySpeechPunctuation, value: true)
         }
     }
 
     func testSpeakingLanguageStyle() {
         let style = StringStyle(.speakingLanguage("pt-BR"))
-        for (style, fullstyle) in additiviePermutations(for: style) {
-            XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+        for (style, fullStyle) in additivePermutations(for: style) {
+            XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: NSAttributedString.Key.accessibilitySpeechLanguage, value: "pt-BR")
         }
     }
 
     func testSpeakingPitchStyle() {
         let style = StringStyle(.speakingPitch(1.5))
-        for (style, fullstyle) in additiviePermutations(for: style) {
-            XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+        for (style, fullStyle) in additivePermutations(for: style) {
+            XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, key: NSAttributedString.Key.accessibilitySpeechPitch, value: 1.5)
         }
     }
 
-    func testPronuciationStyle() {
+    func testPronunciationStyle() {
         if #available(iOS 11, tvOS 11, watchOS 4, *) {
             let style = StringStyle(.speakingPronunciation("ˈɡɪər"))
-            for (style, fullstyle) in additiviePermutations(for: style) {
-                XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+            for (style, fullStyle) in additivePermutations(for: style) {
+                XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
                 BONAssert(attributes: style.attributes, key: .accessibilitySpeechIPANotation, value: "ˈɡɪər")
             }
         }
@@ -130,8 +130,8 @@ class StringStyleTests: XCTestCase {
     func testShouldQueueSpeechAnnouncement() {
         if #available(iOS 11, tvOS 11, watchOS 4, *) {
             let style = StringStyle(.shouldQueueSpeechAnnouncement(true))
-            for (style, fullstyle) in additiviePermutations(for: style) {
-                XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+            for (style, fullStyle) in additivePermutations(for: style) {
+                XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
                 BONAssert(attributes: style.attributes, key: .accessibilitySpeechQueueAnnouncement, value: true as NSNumber)
             }
         }
@@ -140,8 +140,8 @@ class StringStyleTests: XCTestCase {
     func testHeadingLevel() {
         if #available(iOS 11, tvOS 11, watchOS 4, *) {
             let style = StringStyle(.headingLevel(.four))
-            for (style, fullstyle) in additiviePermutations(for: style) {
-                XCTAssertTrue(fullstyle == true || style.attributes.count == 1)
+            for (style, fullStyle) in additivePermutations(for: style) {
+                XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
                 BONAssert(attributes: style.attributes, key: .accessibilityTextHeadingLevel, value: 4 as NSNumber)
             }
         }
@@ -151,7 +151,7 @@ class StringStyleTests: XCTestCase {
 
     func testAlignmentStyle() {
         let style = StringStyle(.alignment(.center))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             BONAssert(attributes: style.attributes, query: \.alignment, value: .center)
         }
@@ -221,7 +221,7 @@ class StringStyleTests: XCTestCase {
 
     func testNumberSpacingStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .numberSpacing(.monospaced))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -244,7 +244,7 @@ class StringStyleTests: XCTestCase {
 
     func testNumberCaseStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .numberCase(.lower))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -267,7 +267,7 @@ class StringStyleTests: XCTestCase {
 
     func testFractionsStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .fractions(.diagonal))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -290,7 +290,7 @@ class StringStyleTests: XCTestCase {
 
     func testSuperscriptStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .superscript(true))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -313,7 +313,7 @@ class StringStyleTests: XCTestCase {
 
     func testSubscriptStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .`subscript`(true))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -336,7 +336,7 @@ class StringStyleTests: XCTestCase {
 
     func testOrdinalsStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .ordinals(true))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -359,7 +359,7 @@ class StringStyleTests: XCTestCase {
 
     func testScientificInferiorsStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .scientificInferiors(true))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -382,7 +382,7 @@ class StringStyleTests: XCTestCase {
 
     func testSmallCapsStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .smallCaps(.fromUppercase))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -405,7 +405,7 @@ class StringStyleTests: XCTestCase {
 
     func testStylisticAlternatesStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .stylisticAlternates(.two(on: true)))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -428,7 +428,7 @@ class StringStyleTests: XCTestCase {
 
     func testContextualAlternatesStyle() {
         let style = StringStyle(.font(BONFont(name: "EBGaramond12-Regular", size: 24)!), .contextualAlternates(.contextualAlternates(on: false)))
-        for (style, fullStyle) in additiviePermutations(for: style) {
+        for (style, fullStyle) in additivePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
             let font = style.attributes[.font] as? BONFont
             XCTAssertNotNil(font)
@@ -643,7 +643,7 @@ class StringStyleTests: XCTestCase {
 
     func testAdobeTracking() {
         let style = StringStyle(.tracking(.adobe(300)))
-        for (style, _) in additiviePermutations(for: style) {
+        for (style, _) in additivePermutations(for: style) {
             let testKernAttribute = { (fontSize: CGFloat) -> CGFloat in
                 let font = BONFont(name: "Avenir-Book", size: fontSize)!
                 let newStyle = style.byAdding(.font(font))
@@ -658,7 +658,7 @@ class StringStyleTests: XCTestCase {
 
     func testPointTracking() {
         let style = StringStyle(.tracking(.point(10)))
-        for (style, _) in additiviePermutations(for: style) {
+        for (style, _) in additivePermutations(for: style) {
             let testKernAttribute = { (fontSize: CGFloat) -> CGFloat in
                 let font = BONFont(name: "Avenir-Book", size: fontSize)!
                 let newStyle = style.byAdding(.font(font))
@@ -671,13 +671,13 @@ class StringStyleTests: XCTestCase {
         }
     }
 
-    /// Return the result of various addititve operations with the passed style:
+    /// Return the result of various additive operations with the passed style:
     /// - parameter for: the style to check
     /// - returns: The additive style permutations:
     ///   - the passed style
     ///   - an empty style that is updated by the passed style object
     ///   - a fully populated style object that is updated by the passed style object
-    func additiviePermutations(for style: StringStyle) -> [(style: StringStyle, fullStyle: Bool)] {
+    func additivePermutations(for style: StringStyle) -> [(style: StringStyle, fullStyle: Bool)] {
         var emptyStyle = StringStyle()
         emptyStyle.add(stringStyle: style)
         var updated = fullStyle

--- a/Tests/AttributedStringStyleTests.swift
+++ b/Tests/AttributedStringStyleTests.swift
@@ -153,7 +153,7 @@ class StringStyleTests: XCTestCase {
         let style = StringStyle(.alignment(.center))
         for (style, fullStyle) in additiviePermutations(for: style) {
             XCTAssertTrue(fullStyle == true || style.attributes.count == 1)
-            BONAssert(attributes: style.attributes, query: { $0.alignment }, value: .center)
+            BONAssert(attributes: style.attributes, query: \.alignment, value: .center)
         }
     }
 
@@ -558,15 +558,15 @@ class StringStyleTests: XCTestCase {
     static let floatingPointPropertiesLine = #line
     static let floatingPointProperties: [(NSParagraphStyle) -> CGFloat] = [
         //swiftlint:disable opening_brace
-        { $0.lineSpacing },
-        { $0.paragraphSpacing },
-        { $0.headIndent },
-        { $0.tailIndent },
-        { $0.firstLineHeadIndent },
-        { $0.minimumLineHeight },
-        { $0.maximumLineHeight },
-        { $0.lineHeightMultiple },
-        { $0.paragraphSpacingBefore },
+        \.lineSpacing,
+        \.paragraphSpacing,
+        \.headIndent,
+        \.tailIndent,
+        \.firstLineHeadIndent,
+        \.minimumLineHeight,
+        \.maximumLineHeight,
+        \.lineHeightMultiple,
+        \.paragraphSpacingBefore,
         { CGFloat($0.hyphenationFactor) },
         //swiftlint:enable opening_brace
     ]
@@ -592,10 +592,10 @@ class StringStyleTests: XCTestCase {
             let line = UInt(StringStyleTests.floatingPointPropertiesLine + 2 + index)
             BONAssert(attributes: style.attributes, query: check, float: 10, accuracy: 0.001, line: line)
         }
-        BONAssert(attributes: style.attributes, query: { $0.alignment }, value: .center)
-        BONAssert(attributes: style.attributes, query: { $0.lineBreakMode }, value: .byClipping)
-        BONAssert(attributes: style.attributes, query: { $0.baseWritingDirection }, value: .leftToRight)
-        BONAssert(attributes: style.attributes, query: { $0.allowsDefaultTighteningForTruncation }, value: true)
+        BONAssert(attributes: style.attributes, query: \.alignment, value: .center)
+        BONAssert(attributes: style.attributes, query: \.lineBreakMode, value: .byClipping)
+        BONAssert(attributes: style.attributes, query: \.baseWritingDirection, value: .leftToRight)
+        BONAssert(attributes: style.attributes, query: \.allowsDefaultTighteningForTruncation, value: true)
     }
 
     func testParagraphStyleAdd() {
@@ -635,10 +635,10 @@ class StringStyleTests: XCTestCase {
             let line = UInt(StringStyleTests.floatingPointPropertiesLine + 2 + index)
             BONAssert(attributes: style.attributes, query: check, float: 10, accuracy: 0.001, line: line)
         }
-        BONAssert(attributes: style.attributes, query: { $0.alignment }, value: .center)
-        BONAssert(attributes: style.attributes, query: { $0.lineBreakMode }, value: .byClipping)
-        BONAssert(attributes: style.attributes, query: { $0.baseWritingDirection }, value: .leftToRight)
-        BONAssert(attributes: style.attributes, query: { $0.allowsDefaultTighteningForTruncation }, value: true)
+        BONAssert(attributes: style.attributes, query: \.alignment, value: .center)
+        BONAssert(attributes: style.attributes, query: \.lineBreakMode, value: .byClipping)
+        BONAssert(attributes: style.attributes, query: \.baseWritingDirection, value: .leftToRight)
+        BONAssert(attributes: style.attributes, query: \.allowsDefaultTighteningForTruncation, value: true)
     }
 
     func testAdobeTracking() {

--- a/Tests/ComposableTests.swift
+++ b/Tests/ComposableTests.swift
@@ -127,19 +127,19 @@ class ComposableTests: XCTestCase {
             XCTAssertEqual(value, expected, line: line)
         }
 
-        check(forPart: .paragraphSpacingAfter(10), { $0.paragraphSpacing }, 10)
-        check(forPart: .alignment(.center), { $0.alignment }, .center)
-        check(forPart: .firstLineHeadIndent(10), { $0.firstLineHeadIndent }, 10)
-        check(forPart: .headIndent(10), { $0.headIndent }, 10)
-        check(forPart: .tailIndent(10), { $0.tailIndent }, 10)
-        check(forPart: .lineBreakMode(.byClipping), { $0.lineBreakMode }, .byClipping)
-        check(forPart: .minimumLineHeight(10), { $0.minimumLineHeight }, 10)
-        check(forPart: .maximumLineHeight(10), { $0.maximumLineHeight }, 10)
-        check(forPart: .baseWritingDirection(.leftToRight), { $0.baseWritingDirection }, .leftToRight)
-        check(forPart: .lineHeightMultiple(10), { $0.lineHeightMultiple }, 10)
-        check(forPart: .paragraphSpacingBefore(10), { $0.paragraphSpacingBefore }, 10)
-        check(forPart: .hyphenationFactor(10), { $0.hyphenationFactor }, 10)
-        check(forPart: .allowsDefaultTighteningForTruncation(true), { $0.allowsDefaultTighteningForTruncation }, true)
+        check(forPart: .paragraphSpacingAfter(10), \.paragraphSpacing, 10)
+        check(forPart: .alignment(.center), \.alignment, .center)
+        check(forPart: .firstLineHeadIndent(10), \.firstLineHeadIndent, 10)
+        check(forPart: .headIndent(10), \.headIndent, 10)
+        check(forPart: .tailIndent(10), \.tailIndent, 10)
+        check(forPart: .lineBreakMode(.byClipping), \.lineBreakMode, .byClipping)
+        check(forPart: .minimumLineHeight(10), \.minimumLineHeight, 10)
+        check(forPart: .maximumLineHeight(10), \.maximumLineHeight, 10)
+        check(forPart: .baseWritingDirection(.leftToRight), \.baseWritingDirection, .leftToRight)
+        check(forPart: .lineHeightMultiple(10), \.lineHeightMultiple, 10)
+        check(forPart: .paragraphSpacingBefore(10), \.paragraphSpacingBefore, 10)
+        check(forPart: .hyphenationFactor(10), \.hyphenationFactor, 10)
+        check(forPart: .allowsDefaultTighteningForTruncation(true), \.allowsDefaultTighteningForTruncation, true)
     }
 
     func testInitialParagraphStyle() {

--- a/Tests/ComposableTests.swift
+++ b/Tests/ComposableTests.swift
@@ -214,7 +214,7 @@ class ComposableTests: XCTestCase {
     func testKerningStrippingOnLastCharacter() {
         let styleWithTracking = StringStyle(.tracking(.point(0.5)))
 
-        let pairsline = #line; let testCases: [(input: String, lastCharacterUnicodeLength: Int)] = [
+        let pairsLine = #line; let testCases: [(input: String, lastCharacterUnicodeLength: Int)] = [
             ("abc", 1),
             ("abc🍕", 2),
             ("🍕🍕", 2),
@@ -227,7 +227,7 @@ class ComposableTests: XCTestCase {
             let maxRange = NSRange(location: 0, length: styledString.length)
 
             let kerning = styledString.attribute(.kern, at: 0, longestEffectiveRange: &range, in: maxRange) as? Float
-            let testLine = UInt(pairsline + offset + 1)
+            let testLine = UInt(pairsLine + offset + 1)
             XCTAssertEqual(kerning, 0.5, line: testLine)
             XCTAssertEqual(range, NSRange(location: 0, length: styledString.length - testCase.lastCharacterUnicodeLength), line: testLine)
         }

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -76,7 +76,7 @@ class NSAttributedStringDebugTests: XCTestCase {
     }
 
     // ParagraphStyles are a bit interesting, as tabs behave over a line, but multiple paragraph styles can be applied on that line.
-    // I'm not sure how a multi-paragrah line would behave, but this confirms that NSAttributedString doesn't do any coalescing
+    // I'm not sure how a multi-paragraph line would behave, but this confirms that NSAttributedString doesn't do any coalescing
     func testParagraphStyleBehavior() {
         let style1 = NSMutableParagraphStyle()
         style1.lineSpacing = 1000

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -30,7 +30,7 @@ class TransformTests: XCTestCase {
                 ]))
     }
 
-    func assertCorrectColors(inSubstrings substrings: [(substring: String, color: BONColor)], in string: NSAttributedString, file: StaticString = #file, line: UInt = #line) {
+    func assertCorrectColors(inSubstrings substrings: [(substring: String, color: BONColor)], in string: NSAttributedString, file: StaticString = #filePath, line: UInt = #line) {
         // Confirm that lengths and strings match
 
         let reconstructed = substrings.reduce("") { $0 + $1.substring }

--- a/Tests/UIKitBonMotTests.swift
+++ b/Tests/UIKitBonMotTests.swift
@@ -44,7 +44,7 @@ class UIKitBonMotTests: XCTestCase {
         // Update the trait collection and ensure the font grows.
         if #available(iOS 10.0, tvOS 10.0, *) {
             label.adaptText(forTraitCollection: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraLarge))
-            BONAssert(attributes: label.attributedText?.attributes(at: 0, effectiveRange: nil), query: { $0.pointSize }, float: expectedFont.pointSize + 2)
+            BONAssert(attributes: label.attributedText?.attributes(at: 0, effectiveRange: nil), query: \.pointSize, float: expectedFont.pointSize + 2)
             BONAssertColor(inAttributes: label.attributedText?.attributes(at: 0, effectiveRange: nil), key: .foregroundColor, color: adaptiveStyle.color!)
         }
     }
@@ -67,7 +67,7 @@ class UIKitBonMotTests: XCTestCase {
         // Update the trait collection and ensure the font grows.
         if #available(iOS 10.0, tvOS 10.0, *) {
             textField.adaptText(forTraitCollection: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraLarge))
-            BONAssert(attributes: textField.attributedText?.attributes(at: 0, effectiveRange: nil), query: { $0.pointSize }, float: expectedFont.pointSize + 2)
+            BONAssert(attributes: textField.attributedText?.attributes(at: 0, effectiveRange: nil), query: \.pointSize, float: expectedFont.pointSize + 2)
             BONAssertColor(inAttributes: textField.attributedText?.attributes(at: 0, effectiveRange: nil), key: .foregroundColor, color: adaptiveStyle.color!)
         }
     }
@@ -90,7 +90,7 @@ class UIKitBonMotTests: XCTestCase {
         // Update the trait collection and ensure the font grows.
         if #available(iOS 10.0, tvOS 10.0, *) {
             textView.adaptText(forTraitCollection: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraLarge))
-            BONAssert(attributes: textView.attributedText?.attributes(at: 0, effectiveRange: nil), query: { $0.pointSize }, float: expectedFont.pointSize + 2)
+            BONAssert(attributes: textView.attributedText?.attributes(at: 0, effectiveRange: nil), query: \.pointSize, float: expectedFont.pointSize + 2)
             BONAssertColor(inAttributes: textView.attributedText?.attributes(at: 0, effectiveRange: nil), key: .foregroundColor, color: adaptiveStyle.color!)
         }
     }
@@ -114,7 +114,7 @@ class UIKitBonMotTests: XCTestCase {
         if #available(iOS 10.0, tvOS 10.0, *) {
             button.adaptText(forTraitCollection: UITraitCollection(preferredContentSizeCategory: UIContentSizeCategory.extraLarge))
             attributes = button.attributedTitle(for: .normal)?.attributes(at: 0, effectiveRange: nil)
-            BONAssert(attributes: attributes, query: { $0.pointSize }, float: expectedFont.pointSize + 2)
+            BONAssert(attributes: attributes, query: \.pointSize, float: expectedFont.pointSize + 2)
             BONAssertColor(inAttributes: attributes, key: .foregroundColor, color: adaptiveStyle.color!)
         }
     }

--- a/Tests/XMLTagStyleBuilderTests.swift
+++ b/Tests/XMLTagStyleBuilderTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class XMLTagStyleBuilderTests: XCTestCase {
 
     /// There have been concerns about XMLParser's performance. This is a
-    /// baseline test, but doesn't mean much without a comparision.
+    /// baseline test, but doesn't mean much without a comparison.
     func testBasicParserPerformance() {
         let styles = NamedStyles(styles: ["A": styleA, "B": styleB])
 


### PR DESCRIPTION
The only interesting thing (and calling it _interesting_ is probably a stretch) is the commit that fixes a typo in public API by deprecating and renaming it. Please let me know if you think I've done it in a good way, and whether it constitutes a breaking change. (If the latter, we might as well just rename it and skip the deprecation.) It's a tricky case because the renamed parameter has a defaulted value, so consumers may not even be aware that there was a typo.