### PR TITLE
Fix enum for module stability

### DIFF
--- a/Sources/NSAttributedString+BonMot.swift
+++ b/Sources/NSAttributedString+BonMot.swift
@@ -30,7 +30,7 @@ extension NSAttributedString {
 
         for unicode in scalars {
             let replacementString: String?
-            switch Special(rawValue: unicode) {
+            switch Special(rawValue: String(unicode)) {
             case .space?:
                 replacementString = nil
             case .objectReplacementCharacter?:

--- a/Sources/Special.swift
+++ b/Sources/Special.swift
@@ -87,6 +87,7 @@ extension Special {
 
     /// All of the enum values contained in `Special`.
     /// Property kept here for backward compatibility
+    @available(*, deprecated, renamed: "allCases")
     @inlinable
     public static var all: [Special] { allCases }
 

--- a/Sources/Special.swift
+++ b/Sources/Special.swift
@@ -10,7 +10,7 @@
 /// in `Special` are either non-printing (like the various space characters) or
 /// visually ambiguous when viewed with a monospace code font (like the dashes
 /// and hyphens).
-public enum Special: UnicodeScalar {
+public enum Special: String, CaseIterable {
 
     // Keep the cases sorted by unichar value when adding new cases.
     case tab = "\u{0009}"
@@ -86,33 +86,8 @@ extension Special {
     }
 
     /// All of the enum values contained in `Special`.
-    public static var all: [Special] = [
-        .tab,
-        .lineFeed,
-        .verticalTab,
-        .formFeed,
-        .carriageReturn,
-        .space,
-        .nextLine,
-        .noBreakSpace,
-        .enSpace,
-        .emSpace,
-        .figureSpace,
-        .thinSpace,
-        .hairSpace,
-        .zeroWidthSpace,
-        .nonBreakingHyphen,
-        .figureDash,
-        .enDash,
-        .emDash,
-        .horizontalEllipsis,
-        .lineSeparator,
-        .paragraphSeparator,
-        .leftToRightOverride,
-        .narrowNoBreakSpace,
-        .wordJoiner,
-        .minusSign,
-        .objectReplacementCharacter,
-    ]
+    /// Property kept here for backward compatability
+    @inlinable
+    public static var all: [Special] { allCases }
 
 }

--- a/Sources/Special.swift
+++ b/Sources/Special.swift
@@ -86,7 +86,7 @@ extension Special {
     }
 
     /// All of the enum values contained in `Special`.
-    /// Property kept here for backward compatability
+    /// Property kept here for backward compatibility
     @inlinable
     public static var all: [Special] { allCases }
 

--- a/Sources/XMLBuilder.swift
+++ b/Sources/XMLBuilder.swift
@@ -96,7 +96,7 @@ extension Special {
 
     /// Rules describing how to insert values from `Special` into attributed strings.
     public static var insertionRules: [XMLStyleRule] {
-        let rulePairs: [[XMLStyleRule]] = all.map {
+        let rulePairs: [[XMLStyleRule]] = allCases.map {
             let elementName = "BON:\($0.name)"
             // Add the insertion rule and a style rule so we don't look up the style and generate a warning
             return [XMLStyleRule.enter(element: elementName, insert: $0), XMLStyleRule.style(elementName, StringStyle())]

--- a/Tests/NSAttributedStringDebugTests.swift
+++ b/Tests/NSAttributedStringDebugTests.swift
@@ -18,7 +18,7 @@ class NSAttributedStringDebugTests: XCTestCase {
     #endif
 
     func testSpecialFromUnicodeScalar() {
-        let enDash = Special(rawValue: UnicodeScalar("\u{2013}"))
+        let enDash = Special(rawValue: "\u{2013}")
         XCTAssertEqual(enDash, Special.enDash)
     }
 


### PR DESCRIPTION
For working project, I need to build this pod as binary framework. To avoid rebuild it with every new xcode, we build them with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`.

In this mode, swift generate swiftinterface file, which is crucial for module stability

Unfortunately it has bug, which make swiftinterface invalid for BonMot specifically.

Here is link for swift bug: https://bugs.swift.org/browse/SR-14355

Looks like it just skip string literals, because they are not needed,  and do not check that `RawValue` type is not `String`.

I see no other way, rather than change raw type to String. In this way swiftinterface can be compiled.

Additionally I added `CaseIterable` and still keep `all ` for backward compatibility.

I would appreciate if you take my changes and create new release, so I would avoid creating fork of BonMot repo